### PR TITLE
chore(aws-api-mcp-server): upgrade AWS CLI to v1.42.48

### DIFF
--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -67,31 +67,48 @@ jobs:
 
           echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
           echo "::debug::Successfully created upgrade branch: $UPGRADE_BRANCH"
-      - name: Upgrade AWS CLI in aws-api-mcp-server
+      - name: Check and upgrade AWS CLI version
+        id: upgrade
         working-directory: src/aws-api-mcp-server
         run: |
           set -euo pipefail
 
-          echo "::debug::Upgrading AWS CLI dependencies"
+          # Get current installed version
+          CURRENT_VERSION=$(uv run python -c "from importlib.metadata import version; print(version('awscli'))")
+          echo "::debug::Current AWS CLI version: $CURRENT_VERSION"
 
           # Get latest version from PyPI
           LATEST_VERSION=$(uv run --no-project python -c "import urllib.request, json; print(json.loads(urllib.request.urlopen('https://pypi.org/pypi/awscli/json').read())['info']['version'])")
           echo "::debug::Latest AWS CLI version from PyPI: $LATEST_VERSION"
 
-          # Remove existing awscli dependency
-          echo "::debug::Removing existing awscli dependency"
-          uv remove awscli
+          # Set version outputs
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "latest-version=$LATEST_VERSION" >> $GITHUB_OUTPUT
 
-          # Add new version with exact pinning
-          echo "::debug::Adding awscli==$LATEST_VERSION"
-          uv add "awscli==$LATEST_VERSION"
+          # Compare versions
+          if [[ "$CURRENT_VERSION" == "$LATEST_VERSION" ]]; then
+            echo "has-changes=false" >> $GITHUB_OUTPUT
+            echo "::notice::AWS CLI is already up to date (version $CURRENT_VERSION)"
+          else
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+            echo "::notice::Upgrading AWS CLI from $CURRENT_VERSION to $LATEST_VERSION"
 
-          # Sync dependencies
-          echo "::debug::Syncing dependencies"
-          uv sync
+            # Remove existing awscli dependency
+            echo "::debug::Removing existing awscli dependency"
+            uv remove awscli
 
-          echo "::debug::AWS CLI upgrade completed"
+            # Add new version with exact pinning
+            echo "::debug::Adding awscli==$LATEST_VERSION"
+            uv add "awscli==$LATEST_VERSION"
+
+            # Sync dependencies
+            echo "::debug::Syncing dependencies"
+            uv sync
+
+            echo "::debug::AWS CLI upgrade completed"
+          fi
       - name: Configure Git and GPG securely
+        if: steps.upgrade.outputs.has-changes == 'true'
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -125,6 +142,7 @@ jobs:
 
           echo "::debug::GPG configuration completed successfully"
       - name: Commit and push changes
+        if: steps.upgrade.outputs.has-changes == 'true'
         env:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -135,27 +153,22 @@ jobs:
           # Add only the source directory
           git add src/aws-api-mcp-server/
 
-          # Check if there are changes to commit
-          if git diff --cached --quiet; then
-            echo "::warning::No changes to commit"
-            exit 0
-          else
-            # Cache GPG signature
-            echo "commit" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
-            --sign --armor --local-user "$GPG_KEY_ID" <<< "$GPG_PASSPHRASE" > /dev/null
+          # Cache GPG signature
+          echo "commit" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+          --sign --armor --local-user "$GPG_KEY_ID" <<< "$GPG_PASSPHRASE" > /dev/null
 
-            # Create signed commit
-            git commit -m "chore(aws-api-mcp-server): upgrade AWS CLI version" --sign
+          # Create signed commit
+          git commit -m "chore(aws-api-mcp-server): upgrade AWS CLI to v${{ steps.upgrade.outputs.latest-version }}" --sign
 
-            # Pull with rebase to maintain linear history
-            git pull --rebase origin "${{ steps.create-branch.outputs.upgrade-branch }}"
+          # Pull with rebase to maintain linear history
+          git pull --rebase origin "${{ steps.create-branch.outputs.upgrade-branch }}"
 
-            # Push changes
-            git push origin "${{ steps.create-branch.outputs.upgrade-branch }}"
+          # Push changes
+          git push origin "${{ steps.create-branch.outputs.upgrade-branch }}"
 
-            echo "::debug::Successfully committed and pushed changes"
-          fi
+          echo "::debug::Successfully committed and pushed changes"
       - name: Create pull request
+        if: steps.upgrade.outputs.has-changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
@@ -176,13 +189,13 @@ jobs:
           PR_URL="$(gh pr create \
             --base "$BASE_BRANCH" \
             --head "$UPGRADE_BRANCH" \
-            --title "chore(aws-api-mcp-server): upgrade AWS CLI version" \
+            --title "chore(aws-api-mcp-server): upgrade AWS CLI to v${{ steps.upgrade.outputs.latest-version }}" \
             --body "# AWS CLI Version Upgrade
 
           This PR upgrades the AWS CLI version in the aws-api-mcp-server package.
 
           ## Changes
-          * Updated AWS CLI dependencies to latest version
+          * Updated AWS CLI from **v${{ steps.upgrade.outputs.current-version }}** to **v${{ steps.upgrade.outputs.latest-version }}**
 
           ## Checklist
           - [ ] Dependencies have been upgraded

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write  # SECURITY: Only for branch creation and commits
-      pull-requests: write  # SECURITY: Only for PR creation
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -49,22 +49,37 @@ jobs:
           TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
           UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
 
+          echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
+
+          # Check if branch already exists
+          if git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
+            echo "::error::Upgrade branch already exists: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
+          # Configure git user
           git config --local user.email "${{ env.BOT_USER_EMAIL }}"
           git config --local user.name "${{ env.BOT_USER_NAME }}"
 
+          # Create and push branch
           git checkout -b "$UPGRADE_BRANCH"
           git push --set-upstream origin "$UPGRADE_BRANCH"
 
+          # Verify branch was created
+          if ! git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
+            echo "::error::Failed to verify branch creation: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
           echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
+          echo "::debug::Successfully created upgrade branch: $UPGRADE_BRANCH"
       - name: Upgrade AWS CLI in aws-api-mcp-server
         working-directory: src/aws-api-mcp-server
         run: |
           set -euo pipefail
-
-          echo "::debug::Upgrading AWS CLI dependencies"
-          uv remove awscli
-          uv add awscli --upgrade
-          uv sync
+          echo "::debug::Upgrading AWS CLI to latest version"
+          uv add --upgrade awscli
+          echo "::debug::AWS CLI upgrade completed"
       - name: Configure Git and GPG securely
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -138,6 +153,15 @@ jobs:
           UPGRADE_BRANCH="${{ steps.create-branch.outputs.upgrade-branch }}"
           BASE_BRANCH="${{ github.ref_name }}"
 
+          echo "::debug::Creating PR from $UPGRADE_BRANCH to $BASE_BRANCH"
+
+          # Validate branch names
+          if [[ ! "$UPGRADE_BRANCH" =~ ^upgrade/aws-api-mcp-awscli-[0-9]{14}$ ]]; then
+            echo "::error::Invalid upgrade branch format: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
+          # Create PR with validated content
           PR_URL="$(gh pr create \
             --base "$BASE_BRANCH" \
             --head "$UPGRADE_BRANCH" \
@@ -147,7 +171,7 @@ jobs:
           This PR upgrades the AWS CLI version in the aws-api-mcp-server package.
 
           ## Changes
-          * Updated AWS CLI dependencies using \`uv sync --upgrade-package awscli\`
+          * Updated AWS CLI dependencies to latest version
 
           ## Checklist
           - [ ] Dependencies have been upgraded

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -1,0 +1,174 @@
+---
+name: AWS API MCP Server - Upgrade AWS CLI Version
+description: |
+  This workflow upgrades the AWS CLI version in src/aws-api-mcp-server using uv upgrade
+  and creates a pull request with the changes.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'  # Daily at 6 AM Amsterdam time (UTC+1)
+env:
+  BOT_USER_EMAIL: ${{ vars.BOT_USER_EMAIL || '203918161+awslabs-mcp@users.noreply.github.com' }}
+  BOT_USER_NAME: ${{ vars.BOT_USER_NAME || 'awslabs-mcp' }}
+permissions:
+  actions: none
+  attestations: none
+  checks: none
+  contents: none
+  deployments: none
+  discussions: none
+  id-token: none
+  issues: none
+  models: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+jobs:
+  upgrade-awscli:
+    name: Upgrade AWS CLI Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write  # SECURITY: Only for branch creation and commits
+      pull-requests: write  # SECURITY: Only for PR creation
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+      - name: Create upgrade branch
+        id: create-branch
+        run: |
+          set -euo pipefail
+
+          TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
+          UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
+
+          git config --local user.email "${{ env.BOT_USER_EMAIL }}"
+          git config --local user.name "${{ env.BOT_USER_NAME }}"
+
+          git checkout -b "$UPGRADE_BRANCH"
+          git push --set-upstream origin "$UPGRADE_BRANCH"
+
+          echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
+      - name: Upgrade AWS CLI in aws-api-mcp-server
+        working-directory: src/aws-api-mcp-server
+        run: |
+          set -euo pipefail
+
+          echo "::debug::Upgrading AWS CLI dependencies"
+          uv remove awscli
+          uv add awscli --upgrade
+          uv sync
+      - name: Configure Git and GPG securely
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          set -euo pipefail  # SECURITY: Strict error handling
+
+          # Create secure temporary directory for GPG
+          export GNUPGHOME=$(mktemp -d)
+          chmod 700 "$GNUPGHOME"
+          echo "GNUPGHOME=$GNUPGHOME" >> $GITHUB_ENV
+
+          echo "::debug::Setting up secure GPG environment"
+
+          # Configure git user
+          git config --local user.email "${{ env.BOT_USER_EMAIL }}"
+          git config --local user.name "${{ env.BOT_USER_NAME }}"
+
+          # Import GPG key without exposing secrets in command line
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import --quiet
+          echo "$GPG_KEY_ID:6:" | gpg --import-ownertrust --quiet
+
+          # Configure git GPG settings
+          git config --global user.signingkey "$GPG_KEY_ID"
+          git config --global commit.gpgsign true
+          git config --global tag.gpgsign true
+
+          # Test GPG functionality
+          echo "test" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+            --sign --armor --local-user "$GPG_KEY_ID" <<< "$GPG_PASSPHRASE" > /dev/null
+
+          echo "::debug::GPG configuration completed successfully"
+      - name: Commit and push changes
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          echo "::debug::Committing changes"
+
+          # Add only the source directory
+          git add src/aws-api-mcp-server/
+
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "::warning::No changes to commit"
+            exit 0
+          else
+            # Cache GPG signature
+            echo "commit" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+            --sign --armor --local-user "$GPG_KEY_ID" <<< "$GPG_PASSPHRASE" > /dev/null
+
+            # Create signed commit
+            git commit -m "chore(aws-api-mcp-server): upgrade AWS CLI version" --sign
+
+            # Pull with rebase to maintain linear history
+            git pull --rebase origin "${{ steps.create-branch.outputs.upgrade-branch }}"
+
+            # Push changes
+            git push origin "${{ steps.create-branch.outputs.upgrade-branch }}"
+
+            echo "::debug::Successfully committed and pushed changes"
+          fi
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          UPGRADE_BRANCH="${{ steps.create-branch.outputs.upgrade-branch }}"
+          BASE_BRANCH="${{ github.ref_name }}"
+
+          PR_URL="$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$UPGRADE_BRANCH" \
+            --title "chore(aws-api-mcp-server): upgrade AWS CLI version" \
+            --body "# AWS CLI Version Upgrade
+
+          This PR upgrades the AWS CLI version in the aws-api-mcp-server package.
+
+          ## Changes
+          * Updated AWS CLI dependencies using \`uv sync --upgrade-package awscli\`
+
+          ## Checklist
+          - [ ] Dependencies have been upgraded
+          - [ ] Lock file has been updated
+          - [ ] Tests pass with new versions
+
+          ## Acknowledgment
+          By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).")"
+
+          echo "::debug::Successfully created pull request $PR_URL"
+          echo "### :arrow_up: AWS CLI Upgrade Ready" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request $PR_URL created for [$UPGRADE_BRANCH](https://github.com/${{ github.repository }}/tree/$UPGRADE_BRANCH) branch" >> $GITHUB_STEP_SUMMARY
+      - name: Secure GPG cleanup
+        if: always()
+        run: |
+          set +e  # Don't fail on cleanup errors
+          echo "::debug::Performing secure cleanup"
+          if [[ -n "${GNUPGHOME:-}" && -d "$GNUPGHOME" ]]; then
+            rm -rf "$GNUPGHOME"
+            echo "::debug::Cleaned up GPG directory"
+          fi
+          gpgconf --kill gpg-agent 2>/dev/null || true
+          unset GPG_PRIVATE_KEY GPG_PASSPHRASE GPG_KEY_ID GNUPGHOME 2>/dev/null || true
+          echo "::debug::Secure cleanup completed"

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -51,12 +51,6 @@ jobs:
 
           echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
 
-          # Check if branch already exists
-          if git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
-            echo "::error::Upgrade branch already exists: $UPGRADE_BRANCH" >&2
-            exit 1
-          fi
-
           # Configure git user
           git config --local user.email "${{ env.BOT_USER_EMAIL }}"
           git config --local user.name "${{ env.BOT_USER_NAME }}"
@@ -77,8 +71,25 @@ jobs:
         working-directory: src/aws-api-mcp-server
         run: |
           set -euo pipefail
-          echo "::debug::Upgrading AWS CLI to latest version"
-          uv add --upgrade awscli
+
+          echo "::debug::Upgrading AWS CLI dependencies"
+
+          # Get latest version from PyPI
+          LATEST_VERSION=$(uv run --no-project python -c "import urllib.request, json; print(json.loads(urllib.request.urlopen('https://pypi.org/pypi/awscli/json').read())['info']['version'])")
+          echo "::debug::Latest AWS CLI version from PyPI: $LATEST_VERSION"
+
+          # Remove existing awscli dependency
+          echo "::debug::Removing existing awscli dependency"
+          uv remove awscli
+
+          # Add new version with exact pinning
+          echo "::debug::Adding awscli==$LATEST_VERSION"
+          uv add "awscli==$LATEST_VERSION"
+
+          # Sync dependencies
+          echo "::debug::Syncing dependencies"
+          uv sync
+
           echo "::debug::AWS CLI upgrade completed"
       - name: Configure Git and GPG securely
         env:

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -41,32 +41,6 @@ jobs:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
-      - name: Create upgrade branch
-        id: create-branch
-        run: |
-          set -euo pipefail
-
-          TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
-          UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
-
-          echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
-
-          # Configure git user
-          git config --local user.email "${{ env.BOT_USER_EMAIL }}"
-          git config --local user.name "${{ env.BOT_USER_NAME }}"
-
-          # Create and push branch
-          git checkout -b "$UPGRADE_BRANCH"
-          git push --set-upstream origin "$UPGRADE_BRANCH"
-
-          # Verify branch was created
-          if ! git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
-            echo "::error::Failed to verify branch creation: $UPGRADE_BRANCH" >&2
-            exit 1
-          fi
-
-          echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
-          echo "::debug::Successfully created upgrade branch: $UPGRADE_BRANCH"
       - name: Check and upgrade AWS CLI version
         id: upgrade
         working-directory: src/aws-api-mcp-server
@@ -107,6 +81,33 @@ jobs:
 
             echo "::debug::AWS CLI upgrade completed"
           fi
+      - name: Create upgrade branch
+        if: steps.upgrade.outputs.has-changes == 'true'
+        id: create-branch
+        run: |
+          set -euo pipefail
+
+          TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
+          UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
+
+          echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
+
+          # Configure git user
+          git config --local user.email "${{ env.BOT_USER_EMAIL }}"
+          git config --local user.name "${{ env.BOT_USER_NAME }}"
+
+          # Create and push branch
+          git checkout -b "$UPGRADE_BRANCH"
+          git push --set-upstream origin "$UPGRADE_BRANCH"
+
+          # Verify branch was created
+          if ! git ls-remote --heads origin "$UPGRADE_BRANCH" | grep -q "$UPGRADE_BRANCH"; then
+            echo "::error::Failed to verify branch creation: $UPGRADE_BRANCH" >&2
+            exit 1
+          fi
+
+          echo "upgrade-branch=$UPGRADE_BRANCH" >> $GITHUB_OUTPUT
+          echo "::debug::Successfully created upgrade branch: $UPGRADE_BRANCH"
       - name: Configure Git and GPG securely
         if: steps.upgrade.outputs.has-changes == 'true'
         env:

--- a/.github/workflows/aws-api-mcp-upgrade-version.yml
+++ b/.github/workflows/aws-api-mcp-upgrade-version.yml
@@ -87,8 +87,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
-          UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-$TIMESTAMP"
+          LATEST_VERSION="${{ steps.upgrade.outputs.latest-version }}"
+          UPGRADE_BRANCH="upgrade/aws-api-mcp-awscli-v$LATEST_VERSION"
 
           echo "::debug::Creating upgrade branch: $UPGRADE_BRANCH"
 
@@ -181,7 +181,7 @@ jobs:
           echo "::debug::Creating PR from $UPGRADE_BRANCH to $BASE_BRANCH"
 
           # Validate branch names
-          if [[ ! "$UPGRADE_BRANCH" =~ ^upgrade/aws-api-mcp-awscli-[0-9]{14}$ ]]; then
+          if [[ ! "$UPGRADE_BRANCH" =~ ^upgrade/aws-api-mcp-awscli-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid upgrade branch format: $UPGRADE_BRANCH" >&2
             exit 1
           fi

--- a/src/aws-api-mcp-server/pyproject.toml
+++ b/src/aws-api-mcp-server/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.11.0",
     "pydantic>=2.10.6",
-    "awscli==1.42.40",
     "boto3>=1.38.18",
     "botocore>=1.38.18",
     "python-json-logger>=2.0.7",
@@ -20,6 +19,7 @@ dependencies = [
     "importlib_resources>=6.0.0",
     "requests>=2.32.4",
     "python-frontmatter>=1.1.0",
+    "awscli==1.42.48",
 ]
 license = {text = "Apache-2.0"}
 license-files = ["LICENSE", "NOTICE" ]

--- a/src/aws-api-mcp-server/uv.lock
+++ b/src/aws-api-mcp-server/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.42.40"
+version = "1.42.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -64,9 +64,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/c6/dce39f736f1fe59fd688fb864252392fa1d90e9a5709491f79dbe897f9d4/awscli-1.42.40.tar.gz", hash = "sha256:37ed937ecd989531d1cfa193a605a7145bb75dbaea6cd11211dae95ef56ed646", size = 1889482, upload-time = "2025-09-26T19:23:43.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/d7/7341749bf70c233fb864f1fb8b4e9594eb721d908e9b60bb8b2eb4528aa2/awscli-1.42.48.tar.gz", hash = "sha256:f5c074e853b885c28bc73639b2a1b1481cae28147498687cd5943b362623b772", size = 1891209, upload-time = "2025-10-08T19:24:20.088Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/35/27510c2ce686d5827b403e4d3d656082d795be9a9af83ae675429964e068/awscli-1.42.40-py3-none-any.whl", hash = "sha256:c27ca5c937cc6386ecc2e25cda6fc0fb545a15b13db1bdcbef5d003de6f92f99", size = 4663622, upload-time = "2025-09-26T19:23:41.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a4/1dc9e1e54a8ce8eb5031e6e0ce333f61764e19f0b0cf60368b08e81e38b8/awscli-1.42.48-py3-none-any.whl", hash = "sha256:46a13d779ff050c098a6d1499c98f2c8f3f1cca0af38f437fb1520ef6fd4e81d", size = 4667602, upload-time = "2025-10-08T19:24:17.022Z" },
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "awscli", specifier = "==1.42.40" },
+    { name = "awscli", specifier = "==1.42.48" },
     { name = "boto3", specifier = ">=1.38.18" },
     { name = "botocore", specifier = ">=1.38.18" },
     { name = "importlib-resources", specifier = ">=6.0.0" },
@@ -144,16 +144,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.40.40"
+version = "1.40.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/5a/43a7fea503ad14fa79819f2b3103a38977fb587a3663d1ac6e958fccf592/botocore-1.40.40.tar.gz", hash = "sha256:78eb121a16a6481ed0f6e1aebe53a4f23aa121f34466846c13a5ca48fa980e31", size = 14363370, upload-time = "2025-09-26T19:23:37.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/20/c71c9417bd2fc37bfef48df1ee8f1178b832ee3c12c4459663dfeb2c00d4/botocore-1.40.48.tar.gz", hash = "sha256:18bed348ce707aa896065b424f36a0b8d542fa6810e9165618e105b1abf34e7e", size = 14403422, upload-time = "2025-10-08T19:24:13.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/5e/3bbf6d34cbf307c1b9e58e0204ceba2d35bbc0c93b4e3b3cc895aae0a5fd/botocore-1.40.40-py3-none-any.whl", hash = "sha256:68506142b3cde93145ef3ee0268f2444f2b68ada225a151f714092bbd3d6516a", size = 14031738, upload-time = "2025-09-26T19:23:35.475Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/1f1427b166880c7820ac362eee7da62f6e24e246c60ea9f0d72d77296ce2/botocore-1.40.48-py3-none-any.whl", hash = "sha256:34795305bb5aa670befcbdc936fd144a0af5db5323d78e7245dbd6aa246bf3db", size = 14073863, upload-time = "2025-10-08T19:24:09.933Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# AWS CLI Version Upgrade

This PR upgrades the AWS CLI version in the aws-api-mcp-server package.

## Changes
* Updated AWS CLI from **v1.42.40** to **v1.42.48**

## Checklist
- [ ] Dependencies have been upgraded
- [ ] Lock file has been updated
- [ ] Tests pass with new versions

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).